### PR TITLE
log: Do not force colors in global logger configuration

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -32,7 +32,7 @@ import (
 func SetupGlobalLogger(level string) error {
 	logrus.SetFormatter(&logrus.TextFormatter{
 		DisableTimestamp: true,
-		ForceColors:      true,
+		ForceColors:      false,
 	})
 
 	lvl, err := logrus.ParseLevel(level)


### PR DESCRIPTION
calling environments can force colors if really necessary with `CLICOLORS=1`
otherwise, respect not coloring output to non-ttys etc. by default.