### PR TITLE
Move from ioutil to os/io packages

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -18,7 +18,6 @@ package command
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -209,20 +208,20 @@ func TestFailureRunSilentSuccessOutput(t *testing.T) {
 }
 
 func TestSuccessLogWriter(t *testing.T) {
-	f, err := ioutil.TempFile("", "log")
+	f, err := os.CreateTemp("", "log")
 	require.Nil(t, err)
 	defer func() { require.Nil(t, os.Remove(f.Name())) }()
 
 	res, err := New("echo", "Hello World").AddWriter(f).RunSuccessOutput()
 	require.Nil(t, err)
 
-	content, err := ioutil.ReadFile(f.Name())
+	content, err := os.ReadFile(f.Name())
 	require.Nil(t, err)
 	require.Equal(t, res.Output(), string(content))
 }
 
 func TestSuccessLogWriterMultiple(t *testing.T) {
-	f, err := ioutil.TempFile("", "log")
+	f, err := os.CreateTemp("", "log")
 	require.Nil(t, err)
 	defer func() { require.Nil(t, os.Remove(f.Name())) }()
 	b := &bytes.Buffer{}
@@ -233,27 +232,27 @@ func TestSuccessLogWriterMultiple(t *testing.T) {
 		RunSuccessOutput()
 	require.Nil(t, err)
 
-	content, err := ioutil.ReadFile(f.Name())
+	content, err := os.ReadFile(f.Name())
 	require.Nil(t, err)
 	require.Equal(t, res.Output(), string(content))
 	require.Equal(t, res.Output(), b.String())
 }
 
 func TestSuccessLogWriterSilent(t *testing.T) {
-	f, err := ioutil.TempFile("", "log")
+	f, err := os.CreateTemp("", "log")
 	require.Nil(t, err)
 	defer func() { require.Nil(t, os.Remove(f.Name())) }()
 
 	err = New("echo", "Hello World").AddWriter(f).RunSilentSuccess()
 	require.Nil(t, err)
 
-	content, err := ioutil.ReadFile(f.Name())
+	content, err := os.ReadFile(f.Name())
 	require.Nil(t, err)
 	require.Empty(t, content)
 }
 
 func TestSuccessLogWriterStdErr(t *testing.T) {
-	f, err := ioutil.TempFile("", "log")
+	f, err := os.CreateTemp("", "log")
 	require.Nil(t, err)
 	defer func() { require.Nil(t, os.Remove(f.Name())) }()
 
@@ -261,13 +260,13 @@ func TestSuccessLogWriterStdErr(t *testing.T) {
 		AddWriter(f).RunSuccessOutput()
 	require.Nil(t, err)
 
-	content, err := ioutil.ReadFile(f.Name())
+	content, err := os.ReadFile(f.Name())
 	require.Nil(t, err)
 	require.Equal(t, res.Error(), string(content))
 }
 
 func TestSuccessLogWriterStdErrAndStdOut(t *testing.T) {
-	f, err := ioutil.TempFile("", "log")
+	f, err := os.CreateTemp("", "log")
 	require.Nil(t, err)
 	defer func() { require.Nil(t, os.Remove(f.Name())) }()
 
@@ -275,14 +274,14 @@ func TestSuccessLogWriterStdErrAndStdOut(t *testing.T) {
 		AddWriter(f).RunSuccessOutput()
 	require.Nil(t, err)
 
-	content, err := ioutil.ReadFile(f.Name())
+	content, err := os.ReadFile(f.Name())
 	require.Nil(t, err)
 	require.Contains(t, string(content), res.Output())
 	require.Contains(t, string(content), res.Error())
 }
 
 func TestSuccessLogWriterStdErrAndStdOutOnlyStdErr(t *testing.T) {
-	f, err := ioutil.TempFile("", "log")
+	f, err := os.CreateTemp("", "log")
 	require.Nil(t, err)
 	defer func() { require.Nil(t, os.Remove(f.Name())) }()
 
@@ -290,13 +289,13 @@ func TestSuccessLogWriterStdErrAndStdOutOnlyStdErr(t *testing.T) {
 		AddErrorWriter(f).RunSuccessOutput()
 	require.Nil(t, err)
 
-	content, err := ioutil.ReadFile(f.Name())
+	content, err := os.ReadFile(f.Name())
 	require.Nil(t, err)
 	require.Equal(t, res.Error(), string(content))
 }
 
 func TestSuccessLogWriterStdErrAndStdOutOnlyStdOut(t *testing.T) {
-	f, err := ioutil.TempFile("", "log")
+	f, err := os.CreateTemp("", "log")
 	require.Nil(t, err)
 	defer func() { require.Nil(t, os.Remove(f.Name())) }()
 
@@ -304,7 +303,7 @@ func TestSuccessLogWriterStdErrAndStdOutOnlyStdOut(t *testing.T) {
 		AddOutputWriter(f).RunSuccessOutput()
 	require.Nil(t, err)
 
-	content, err := ioutil.ReadFile(f.Name())
+	content, err := os.ReadFile(f.Name())
 	require.Nil(t, err)
 	require.Equal(t, res.Output(), string(content))
 }

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -19,7 +19,6 @@ package editor
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -139,7 +138,7 @@ func (e Editor) Launch(path string) error {
 // the contents of the file after launch, any errors that occur, and the path of the
 // temporary file so the caller can clean it up as needed.
 func (e Editor) LaunchTempFile(prefix, suffix string, r io.Reader) (bytes []byte, path string, err error) {
-	f, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%s*%s", prefix, suffix))
+	f, err := os.CreateTemp("", fmt.Sprintf("%s*%s", prefix, suffix))
 	if err != nil {
 		return nil, "", err
 	}
@@ -154,7 +153,7 @@ func (e Editor) LaunchTempFile(prefix, suffix string, r io.Reader) (bytes []byte
 	if err := e.Launch(path); err != nil {
 		return nil, path, err
 	}
-	bytes, err = ioutil.ReadFile(path)
+	bytes, err = os.ReadFile(path)
 	return bytes, path, err
 }
 

--- a/editor/editor_test.go
+++ b/editor/editor_test.go
@@ -18,7 +18,6 @@ package editor
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -51,7 +50,7 @@ func TestEditor(t *testing.T) {
 		t.Fatalf("no temp file: %s", path)
 	}
 	defer os.Remove(path)
-	if disk, err := ioutil.ReadFile(path); err != nil || !bytes.Equal(contents, disk) {
+	if disk, err := os.ReadFile(path); err != nil || !bytes.Equal(contents, disk) {
 		t.Errorf("unexpected file on disk: %v %s", err, string(disk))
 	}
 	if !bytes.Equal(contents, []byte(testStr)) {

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -20,7 +20,7 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"hash"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,7 +35,7 @@ func TestSHA512ForFile(t *testing.T) {
 	}{
 		{ // success
 			prepare: func() string {
-				f, err := ioutil.TempFile("", "")
+				f, err := os.CreateTemp("", "")
 				require.Nil(t, err)
 
 				_, err = f.WriteString("test")
@@ -74,7 +74,7 @@ func TestSHA256ForFile(t *testing.T) {
 	}{
 		{ // success
 			prepare: func() string {
-				f, err := ioutil.TempFile("", "")
+				f, err := os.CreateTemp("", "")
 				require.Nil(t, err)
 
 				_, err = f.WriteString("test")
@@ -111,7 +111,7 @@ func TestForFile(t *testing.T) {
 	}{
 		{ // success
 			prepare: func() (string, hash.Hash) {
-				f, err := ioutil.TempFile("", "")
+				f, err := os.CreateTemp("", "")
 				require.Nil(t, err)
 
 				_, err = f.WriteString("test")

--- a/http/agent.go
+++ b/http/agent.go
@@ -19,7 +19,7 @@ package http
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"time"
@@ -215,7 +215,7 @@ func (impl *defaultAgentImplementation) SendGetRequest(client *http.Client, url 
 func (a *Agent) readResponse(response *http.Response) (body []byte, err error) {
 	// Read the response body
 	defer response.Body.Close()
-	body, err = ioutil.ReadAll(response.Body)
+	body, err = io.ReadAll(response.Body)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err, "reading the response body from %s", response.Request.URL)

--- a/http/http.go
+++ b/http/http.go
@@ -18,7 +18,7 @@ package http
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -60,7 +60,7 @@ func GetURLResponseWithTimeOut(url string, timeout time.Duration) ([]byte, error
 		return nil, errors.New(errMsg)
 	}
 
-	respBytes, ioErr := ioutil.ReadAll(resp.Body)
+	respBytes, ioErr := io.ReadAll(resp.Body)
 	if ioErr != nil {
 		return nil, errors.Wrapf(ioErr, "could not handle the response body for %s", url)
 	}

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -93,7 +92,7 @@ func TestAgentPost(t *testing.T) {
 	resp := &http.Response{
 		Status:        "200 OK",
 		StatusCode:    200,
-		Body:          ioutil.NopCloser(bytes.NewReader([]byte("hello sig-release!"))),
+		Body:          io.NopCloser(bytes.NewReader([]byte("hello sig-release!"))),
 		ContentLength: 18,
 		Close:         true,
 		Request:       &http.Request{},
@@ -122,7 +121,7 @@ func TestAgentGet(t *testing.T) {
 	resp := &http.Response{
 		Status:        "200 OK",
 		StatusCode:    200,
-		Body:          ioutil.NopCloser(bytes.NewReader([]byte("hello sig-release!"))),
+		Body:          io.NopCloser(bytes.NewReader([]byte("hello sig-release!"))),
 		ContentLength: 18,
 		Close:         true,
 		Request:       &http.Request{},
@@ -151,7 +150,7 @@ func TestAgentOptions(t *testing.T) {
 	resp := &http.Response{
 		Status:        "Fake not found",
 		StatusCode:    404,
-		Body:          ioutil.NopCloser(bytes.NewReader([]byte("hello sig-release!"))),
+		Body:          io.NopCloser(bytes.NewReader([]byte("hello sig-release!"))),
 		ContentLength: 18,
 		Close:         true,
 		Request:       &http.Request{},

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package log_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -28,7 +27,7 @@ import (
 )
 
 func TestToFile(t *testing.T) {
-	file, err := ioutil.TempFile("", "log-test-")
+	file, err := os.CreateTemp("", "log-test-")
 	require.Nil(t, err)
 	defer os.Remove(file.Name())
 
@@ -36,7 +35,7 @@ func TestToFile(t *testing.T) {
 	require.Nil(t, log.ToFile(file.Name()))
 	logrus.Info("test")
 
-	content, err := ioutil.ReadFile(file.Name())
+	content, err := os.ReadFile(file.Name())
 	require.Nil(t, err)
 
 	require.Contains(t, string(content), "info")

--- a/tar/tar_test.go
+++ b/tar/tar_test.go
@@ -18,7 +18,7 @@ package tar
 
 import (
 	"archive/tar"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -29,14 +29,14 @@ import (
 )
 
 func TestCompress(t *testing.T) {
-	baseTmpDir, err := ioutil.TempDir("", "compress-")
+	baseTmpDir, err := os.MkdirTemp("", "compress-")
 	require.Nil(t, err)
 	defer os.RemoveAll(baseTmpDir)
 
 	for _, fileName := range []string{
 		"1.txt", "2.bin", "3.md",
 	} {
-		require.Nil(t, ioutil.WriteFile(
+		require.Nil(t, os.WriteFile(
 			filepath.Join(baseTmpDir, fileName),
 			[]byte{1, 2, 3},
 			os.FileMode(0o644),
@@ -49,7 +49,7 @@ func TestCompress(t *testing.T) {
 	for _, fileName := range []string{
 		"4.txt", "5.bin", "6.md",
 	} {
-		require.Nil(t, ioutil.WriteFile(
+		require.Nil(t, os.WriteFile(
 			filepath.Join(subTmpDir, fileName),
 			[]byte{4, 5, 6},
 			os.FileMode(0o644),
@@ -104,13 +104,13 @@ func TestExtract(t *testing.T) {
 		0xeb, 0x16, 0x00, 0x00, 0xff, 0xff, 0xe9, 0xde, 0xbe, 0xdf, 0x00, 0x12,
 		0x00, 0x00,
 	}
-	file, err := ioutil.TempFile("", "tarball")
+	file, err := os.CreateTemp("", "tarball")
 	require.Nil(t, err)
 	defer os.Remove(file.Name())
 	_, err = file.Write(tarball)
 	require.Nil(t, err)
 
-	baseTmpDir, err := ioutil.TempDir("", "extract-")
+	baseTmpDir, err := os.MkdirTemp("", "extract-")
 	require.Nil(t, err)
 	require.Nil(t, os.RemoveAll(baseTmpDir))
 	defer os.RemoveAll(baseTmpDir)
@@ -138,7 +138,7 @@ func TestExtract(t *testing.T) {
 }
 
 func TestReadFileFromGzippedTar(t *testing.T) {
-	baseTmpDir, err := ioutil.TempDir("", "tar-read-file-")
+	baseTmpDir, err := os.MkdirTemp("", "tar-read-file-")
 	require.Nil(t, err)
 	defer os.RemoveAll(baseTmpDir)
 
@@ -148,7 +148,7 @@ func TestReadFileFromGzippedTar(t *testing.T) {
 	)
 	testTarPath := filepath.Join(baseTmpDir, "test.tar.gz")
 
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		filepath.Join(baseTmpDir, testFilePath),
 		[]byte(testFileContents),
 		os.FileMode(0o644),
@@ -190,7 +190,7 @@ func TestReadFileFromGzippedTar(t *testing.T) {
 				require.Nil(t, r)
 				require.NotNil(t, err)
 			} else {
-				file, err := ioutil.ReadAll(r)
+				file, err := io.ReadAll(r)
 				require.Nil(t, err)
 				require.Equal(t, tc.want.fileContents, string(file))
 			}

--- a/util/common.go
+++ b/util/common.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -436,7 +435,7 @@ func CopyDirContentsLocal(src, dst string) error {
 			return errors.Wrapf(err, "create destination directory %s", dst)
 		}
 	}
-	files, err := ioutil.ReadDir(src)
+	files, err := os.ReadDir(src)
 	if err != nil {
 		return errors.Wrapf(err, "reading source dir %s", src)
 	}
@@ -531,7 +530,7 @@ func CleanLogFile(logPath string) (err error) {
 	logrus.Debugf("Sanitizing logfile %s", logPath)
 
 	// Open a tempfile to write sanitized log
-	tempFile, err := ioutil.TempFile(os.TempDir(), "temp-release-log-")
+	tempFile, err := os.CreateTemp("", "temp-release-log-")
 	if err != nil {
 		return errors.Wrap(err, "creating temp file for sanitizing log")
 	}

--- a/util/common_test.go
+++ b/util/common_test.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -68,12 +67,12 @@ func TestPackagesAvailableFailure(t *testing.T) {
 }
 
 func TestMoreRecent(t *testing.T) {
-	baseTmpDir, err := ioutil.TempDir("", "")
+	baseTmpDir, err := os.MkdirTemp("", "")
 	require.Nil(t, err)
 
 	// Create test files.
 	testFileOne := filepath.Join(baseTmpDir, "testone.txt")
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		testFileOne,
 		[]byte("file-one-contents"),
 		os.FileMode(0o644),
@@ -82,7 +81,7 @@ func TestMoreRecent(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	testFileTwo := filepath.Join(baseTmpDir, "testtwo.txt")
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		testFileTwo,
 		[]byte("file-two-contents"),
 		os.FileMode(0o644),
@@ -166,14 +165,14 @@ func TestMoreRecent(t *testing.T) {
 }
 
 func TestCopyFile(t *testing.T) {
-	srcDir, err := ioutil.TempDir("", "src")
+	srcDir, err := os.MkdirTemp("", "src")
 	require.Nil(t, err)
-	dstDir, err := ioutil.TempDir("", "dst")
+	dstDir, err := os.MkdirTemp("", "dst")
 	require.Nil(t, err)
 
 	// Create test file.
 	srcFileOnePath := filepath.Join(srcDir, "testone.txt")
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		srcFileOnePath,
 		[]byte("file-one-contents"),
 		os.FileMode(0o644),
@@ -238,21 +237,21 @@ func TestCopyFile(t *testing.T) {
 }
 
 func TestCopyDirContentLocal(t *testing.T) {
-	srcDir, err := ioutil.TempDir("", "src")
+	srcDir, err := os.MkdirTemp("", "src")
 	require.Nil(t, err)
-	dstDir, err := ioutil.TempDir("", "dst")
+	dstDir, err := os.MkdirTemp("", "dst")
 	require.Nil(t, err)
 
 	// Create test file.
 	srcFileOnePath := filepath.Join(srcDir, "testone.txt")
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		srcFileOnePath,
 		[]byte("file-one-contents"),
 		os.FileMode(0o644),
 	))
 
 	srcFileTwoPath := filepath.Join(srcDir, "testtwo.txt")
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		srcFileTwoPath,
 		[]byte("file-two-contents"),
 		os.FileMode(0o644),
@@ -301,19 +300,19 @@ func TestCopyDirContentLocal(t *testing.T) {
 }
 
 func TestRemoveAndReplaceDir(t *testing.T) {
-	dir, err := ioutil.TempDir("", "rm")
+	dir, err := os.MkdirTemp("", "rm")
 	require.Nil(t, err)
 
 	// Create test file.
 	fileOnePath := filepath.Join(dir, "testone.txt")
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		fileOnePath,
 		[]byte("file-one-contents"),
 		os.FileMode(0o644),
 	))
 
 	fileTwoPath := filepath.Join(dir, "testtwo.txt")
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		fileTwoPath,
 		[]byte("file-two-contents"),
 		os.FileMode(0o644),
@@ -358,12 +357,12 @@ func TestRemoveAndReplaceDir(t *testing.T) {
 }
 
 func TestExist(t *testing.T) {
-	dir, err := ioutil.TempDir("", "rm")
+	dir, err := os.MkdirTemp("", "rm")
 	require.Nil(t, err)
 
 	// Create test file.
 	fileOnePath := filepath.Join(dir, "testone.txt")
-	require.Nil(t, ioutil.WriteFile(
+	require.Nil(t, os.WriteFile(
 		fileOnePath,
 		[]byte("file-one-contents"),
 		os.FileMode(0o644),
@@ -551,17 +550,17 @@ func TestCleanLogFile(t *testing.T) {
 	// And expected output
 	cleanLog := line1 + line2 + sanitizedTokenLine + line3 + line4 + line5 + "\n"
 
-	logfile, err := ioutil.TempFile(os.TempDir(), "clean-log-test-")
+	logfile, err := os.CreateTemp("", "clean-log-test-")
 	require.Nil(t, err, "creating test logfile")
 	defer os.Remove(logfile.Name())
-	err = ioutil.WriteFile(logfile.Name(), []byte(originalLog), os.FileMode(0o644))
+	err = os.WriteFile(logfile.Name(), []byte(originalLog), os.FileMode(0o644))
 	require.Nil(t, err, "writing test file")
 
 	// Now, run the cleanLogFile
 	err = CleanLogFile(logfile.Name())
 	require.Nil(t, err, "running log cleaner")
 
-	resultingData, err := ioutil.ReadFile(logfile.Name())
+	resultingData, err := os.ReadFile(logfile.Name())
 	require.Nil(t, err, "reading modified file")
 	require.NotEmpty(t, resultingData)
 


### PR DESCRIPTION
With go1.16 we now default to the os/io packages instead of ioutil. This
should be reflected in the code, too.
