### PR TITLE
Enable dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "release-note-none"
+  open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  labels:
+  labels:  
+    - "area/dependency"
     - "release-note-none"
   open-pull-requests-limit: 10


### PR DESCRIPTION
This enables dependabot updates for k/release to be able to keep our
golang dependencies regularly up-to-date.

Refers to https://github.com/kubernetes/release/pull/2031