### PR TITLE
New function hash.SHA1ForFile()

### DIFF
--- a/hash/hash.go
+++ b/hash/hash.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hash
 
 import (
+	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
@@ -36,6 +37,11 @@ func SHA512ForFile(filename string) (string, error) {
 // SHA256ForFile returns the hex-encoded sha256 hash for the provided filename.
 func SHA256ForFile(filename string) (string, error) {
 	return ForFile(filename, sha256.New())
+}
+
+// SHA1ForFile returns the hex-encoded sha1 hash for the provided filename.
+func SHA1ForFile(filename string) (string, error) {
+	return ForFile(filename, sha1.New())
 }
 
 // ForFile returns the hex-encoded hash for the provided filename and hasher.

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -103,6 +103,43 @@ func TestSHA256ForFile(t *testing.T) {
 	}
 }
 
+func TestSHA1ForFile(t *testing.T) {
+	for _, tc := range []struct {
+		prepare     func() string
+		expected    string
+		shouldError bool
+	}{
+		{ // success
+			prepare: func() string {
+				f, err := os.CreateTemp("", "")
+				require.Nil(t, err)
+
+				_, err = f.WriteString("test")
+				require.Nil(t, err)
+
+				return f.Name()
+			},
+			expected:    "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+			shouldError: false,
+		},
+		{ // error open file
+			prepare:     func() string { return "" },
+			shouldError: true,
+		},
+	} {
+		filename := tc.prepare()
+
+		res, err := kHash.SHA1ForFile(filename)
+
+		if tc.shouldError {
+			require.NotNil(t, err)
+		} else {
+			require.Nil(t, err)
+			require.Equal(t, tc.expected, res)
+		}
+	}
+}
+
 func TestForFile(t *testing.T) {
 	for _, tc := range []struct {
 		prepare     func() (string, hash.Hash)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a new function `SHA1ForFile()` to the hash package. This is needed because some
specs (eg SPDX) require hashing files in SHA1.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:
None
#### Special notes for your reviewer:
Test included
#### Does this PR introduce a user-facing change?


```release-note
New function `hash.SHA1ForFile()` to generate sha1 sums from files
```
