### PR TITLE
Add command.Filter API

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -335,3 +335,23 @@ func TestEnv(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, "123\nbar\ntest", res.OutputTrimNL())
 }
+
+func TestFilterStdout(t *testing.T) {
+	cmd, err := New("echo", "-n", "1 2 2 3").Filter("[25]", "0")
+	require.Nil(t, err)
+
+	res, err := cmd.Add("echo", "-n", "4 5 6 2 2").Run()
+	require.Nil(t, err)
+	require.True(t, res.Success())
+	require.Zero(t, res.ExitCode())
+	require.Equal(t, "\n1 0 0 3\n4 0 6 0 0", res.Output())
+}
+
+func TestFilterStderr(t *testing.T) {
+	res, err := New("bash", "-c", ">&2 echo -n my secret").Filter("secret", "***")
+	require.Nil(t, err)
+	out, err := res.RunSilentSuccessOutput()
+	require.Nil(t, err)
+	require.Equal(t, "my ***", out.Error())
+	require.Empty(t, out.Output())
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This new API brings the ability to output filter commands with a regular expression. We replace all strings matching the expression before sending them to the output writers. This allows us to globally avoid exposing secret information by invoking a command.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Should be later on integrated in k/release to be used by the `git` package.

#### Does this PR introduce a user-facing change?

```release-note
Added `command.Filter(regex, replaceAll string)` API to filter command outputs.
```
