### PR TITLE
update repo-infra to v0.2.4

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,7 +8,7 @@ dependencies:
 
   # k8s.io/repo-infra
   - name: "repo-infra"
-    version: 0.2.1
+    version: 0.2.4
     refPaths:
     - path: mage/boilerplate.go
       match: defaultRepoInfraVersion\s+=\s+"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?

--- a/mage/boilerplate.go
+++ b/mage/boilerplate.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	// repo-infra (used for boilerplate script)
-	defaultRepoInfraVersion = "v0.2.1"
+	defaultRepoInfraVersion = "v0.2.4"
 	repoInfraURLBase        = "https://raw.githubusercontent.com/kubernetes/repo-infra"
 )
 


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

- update repo-infra to v0.2.4
follow up of https://github.com/kubernetes-sigs/release-utils/pull/22


/assign @justaugustus @saschagrunert @Verolop @puerco @xmudrii 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
