### PR TITLE
add setting for go-header to check the header copyright for go files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -166,3 +166,9 @@ linters-settings:
       - typeUnparen
       - unnamedResult
       - unnecessaryBlock
+  goheader:
+    template-path: "scripts/boilerplate/boilerplate.goheader.txt"
+    values:
+      regexp:
+        year: "[2][0-9][0-9][0-9]"
+        copyright-holder: Copyright {{year}} The Kubernetes Authors.

--- a/scripts/boilerplate/boilerplate.goheader.txt
+++ b/scripts/boilerplate/boilerplate.goheader.txt
@@ -1,0 +1,13 @@
+{{copyright-holder}}
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

- add setting for go-header to check the header copyright for go files

this is a test for now and if it works fine we might deprecate the
checks from the repo-infra for the boilerplate


/assign @justaugustus 
cc @kubernetes-sigs/release-engineering @denis-tingaikin @edwarnicke 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
