### PR TITLE
Do not attempt to override version if not devel

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -72,6 +72,11 @@ func GetVersionInfo() Info {
 		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 
+	// Look for the default version and replace it from runtime build info if possible.
+	if info.GitVersion != "devel" {
+		return info
+	}
+
 	// If there is debug info for the module, this binary was installed outside
 	// the normal build process and might not have the ld flags set.
 	bi, ok := debug.ReadBuildInfo()


### PR DESCRIPTION
Signed-off-by: Scott Nichols <n3wscott@chainguard.dev>

So sorry, I missed a guard statement on the version from module info replace.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If version is set to anything aside from "devel", we will use that. Or we attempt to load the debug module info and get version from there. 

Followup to #29 


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
