### PR TITLE
Add mage target for ensuring git config

### DIFF
--- a/mage/git.go
+++ b/mage/git.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mage
+
+import (
+	"github.com/pkg/errors"
+
+	"sigs.k8s.io/release-utils/command"
+)
+
+const (
+	gitConfigNameKey    = "user.name"
+	gitConfigNameValue  = "releng-ci-user"
+	gitConfigEmailKey   = "user.email"
+	gitConfigEmailValue = "nobody@k8s.io"
+)
+
+func CheckGitConfigExists() (bool, error) {
+	userName := command.New(
+		"git",
+		"config",
+		"--global",
+		"--get",
+		gitConfigNameKey,
+	)
+
+	stream, err := userName.RunSuccessOutput()
+	if err != nil {
+		return false, errors.Wrapf(err, "getting git %s", gitConfigNameKey)
+	}
+	if stream.OutputTrimNL() == "" {
+		return false, nil
+	}
+
+	userEmail := command.New(
+		"git",
+		"config",
+		"--global",
+		"--get",
+		gitConfigEmailKey,
+	)
+
+	stream, err = userEmail.RunSuccessOutput()
+	if err != nil {
+		return false, errors.Wrapf(err, "getting git %s", gitConfigEmailKey)
+	}
+	if stream.OutputTrimNL() == "" {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func EnsureGitConfig() error {
+	exists, err := CheckGitConfigExists()
+	if err != nil {
+		return errors.Wrap(err, "ensuring git config")
+	}
+	if exists {
+		return nil
+	}
+
+	if err := command.New(
+		"git",
+		"config",
+		"--global",
+		gitConfigNameKey,
+		gitConfigNameValue,
+	).RunSuccess(); err != nil {
+		return errors.Wrapf(err, "configuring git %s", gitConfigNameKey)
+	}
+
+	if err := command.New(
+		"git",
+		"config",
+		"--global",
+		gitConfigEmailKey,
+		gitConfigEmailValue,
+	).RunSuccess(); err != nil {
+		return errors.Wrapf(err, "configuring git %s", gitConfigEmailKey)
+	}
+
+	return nil
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is required in order to switch the `pull-release-sdk-test` job to the `k8s-ci-builder` image. release-sdk tests expect that git has name and email configured, so commits can be created.

This was configured out of the box in the `releng-ci` image which we use right now, but it is not configured in the `k8s-ci-builder` image. I find it risky to configure this out of the box in the k8s-ci-builder image because that image is used in various places (including our release pipeline). Instead, I want to extend the Test target in the release-sdk repo to do that if needed.

#### Which issue(s) this PR fixes:

Required for https://github.com/kubernetes/test-infra/pull/25127 and https://github.com/kubernetes-sigs/release-sdk/issues/24

#### Special notes for your reviewer:

NB: this is required because we want to use dind (docker-in-docker) for integration tests for the sign package (https://github.com/kubernetes-sigs/release-sdk/issues/24).

#### Does this PR introduce a user-facing change?

```release-note
Add mage target for ensuring git config
```

/assign @saschagrunert @cpanato @puerco @justaugustus 
cc @kubernetes-sigs/release-engineering 