### PR TITLE
CheckGitConfigExists: properly handle non-existing config

### DIFF
--- a/mage/git.go
+++ b/mage/git.go
@@ -39,10 +39,7 @@ func CheckGitConfigExists() (bool, error) {
 	)
 
 	stream, err := userName.RunSuccessOutput()
-	if err != nil {
-		return false, errors.Wrapf(err, "getting git %s", gitConfigNameKey)
-	}
-	if stream.OutputTrimNL() == "" {
+	if err != nil || stream.OutputTrimNL() == "" {
 		return false, nil
 	}
 
@@ -55,10 +52,7 @@ func CheckGitConfigExists() (bool, error) {
 	)
 
 	stream, err = userEmail.RunSuccessOutput()
-	if err != nil {
-		return false, errors.Wrapf(err, "getting git %s", gitConfigEmailKey)
-	}
-	if stream.OutputTrimNL() == "" {
+	if err != nil || stream.OutputTrimNL() == "" {
 		return false, nil
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Git returns status code -1 when running `git config --global --get user.name` without existing `.gitconfig`. With our current implementation, this is considered an error, and the CheckGitConfigExists target would return an error.

This is further causing `EnsureGitConfig` to fail as well instead of creating `.gitconfig`.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/assign @saschagrunert @cpanato @puerco @palnabarun 
cc @kubernetes-sigs/release-engineering 