### PR TITLE
Switch to golang native error wrapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,19 +1,33 @@
 module sigs.k8s.io/release-utils
 
-go 1.16
+go 1.17
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/carolynvs/magex v0.6.1
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be
-	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.5.0
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
-	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.7.1
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed
+)
+
+require (
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/kr/pretty v0.3.0 // indirect
+	github.com/magefile/mage v1.11.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
+	golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86 // indirect
+	golang.org/x/tools v0.1.10 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -48,11 +49,14 @@ github.com/klauspost/compress v1.10.10/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdY
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/pgzip v1.2.4/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/magefile/mage v1.11.0 h1:C/55Ywp9BpgVVclD3lRnSYCwXTYxmSppIgLeDYlNuls=
 github.com/magefile/mage v1.11.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.5.0 h1:rBhB9Rls+yb8kA4x5a/cWxOufWfXt24E+kq4YlbGj3g=
@@ -79,6 +83,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
@@ -174,8 +180,10 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -21,11 +21,12 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
+	"errors"
+	"fmt"
 	"hash"
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -52,7 +53,7 @@ func ForFile(filename string, hasher hash.Hash) (string, error) {
 
 	f, err := os.Open(filename)
 	if err != nil {
-		return "", errors.Wrapf(err, "open file %s", filename)
+		return "", fmt.Errorf("open file %s: %w", filename, err)
 	}
 	defer func() {
 		if err := f.Close(); err != nil {
@@ -62,7 +63,7 @@ func ForFile(filename string, hasher hash.Hash) (string, error) {
 
 	hasher.Reset()
 	if _, err := io.Copy(hasher, f); err != nil {
-		return "", errors.Wrapf(err, "hash file %s", filename)
+		return "", fmt.Errorf("hash file %s: %w", filename, err)
 	}
 
 	return hex.EncodeToString(hasher.Sum(nil)), nil

--- a/http/agent.go
+++ b/http/agent.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -117,7 +116,7 @@ func (a *Agent) Client() *http.Client {
 func (a *Agent) Get(url string) (content []byte, err error) {
 	request, err := a.GetRequest(url)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting GET request")
+		return nil, fmt.Errorf("getting GET request: %w", err)
 	}
 	defer request.Body.Close()
 
@@ -153,7 +152,7 @@ func (a *Agent) GetRequest(url string) (response *http.Response, err error) {
 func (a *Agent) Post(url string, postData []byte) (content []byte, err error) {
 	response, err := a.PostRequest(url, postData)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting post request")
+		return nil, fmt.Errorf("getting post request: %w", err)
 	}
 	defer response.Body.Close()
 
@@ -195,7 +194,7 @@ func (impl *defaultAgentImplementation) SendPostRequest(
 	}
 	response, err = client.Post(url, contentType, bytes.NewBuffer(postData))
 	if err != nil {
-		return response, errors.Wrapf(err, "posting data to %s", url)
+		return response, fmt.Errorf("posting data to %s: %w", url, err)
 	}
 	return response, nil
 }
@@ -206,7 +205,7 @@ func (impl *defaultAgentImplementation) SendGetRequest(client *http.Client, url 
 ) {
 	response, err = client.Get(url)
 	if err != nil {
-		return response, errors.Wrapf(err, "getting %s", url)
+		return response, fmt.Errorf("getting %s: %w", url, err)
 	}
 
 	return response, nil
@@ -218,16 +217,18 @@ func (a *Agent) readResponse(response *http.Response) (body []byte, err error) {
 	defer response.Body.Close()
 	body, err = io.ReadAll(response.Body)
 	if err != nil {
-		return nil, errors.Wrapf(
-			err, "reading the response body from %s", response.Request.URL)
+		return nil, fmt.Errorf(
+			"reading the response body from %s: %w",
+			response.Request.URL, err,
+		)
 	}
 
 	// Check the https response code
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		if a.options.FailOnHTTPError {
-			return nil, errors.New(fmt.Sprintf(
+			return nil, fmt.Errorf(
 				"HTTP error %s for %s", response.Status, response.Request.URL,
-			))
+			)
 		}
 		logrus.Warnf("Got HTTP error but FailOnHTTPError not set: %s", response.Status)
 	}

--- a/log/log.go
+++ b/log/log.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/release-utils/command"
@@ -37,7 +36,7 @@ func SetupGlobalLogger(level string) error {
 
 	lvl, err := logrus.ParseLevel(level)
 	if err != nil {
-		return errors.Wrapf(err, "setting log level to %s", level)
+		return fmt.Errorf("setting log level to %s: %w", level, err)
 	}
 	logrus.SetLevel(lvl)
 	if lvl >= logrus.DebugLevel {
@@ -53,7 +52,7 @@ func SetupGlobalLogger(level string) error {
 func ToFile(fileName string) error {
 	file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE, 0o755)
 	if err != nil {
-		return errors.Wrap(err, "open log file")
+		return fmt.Errorf("open log file: %w", err)
 	}
 
 	writer := io.MultiWriter(logrus.StandardLogger().Out, file)

--- a/mage/dependency.go
+++ b/mage/dependency.go
@@ -17,12 +17,12 @@ limitations under the License.
 package mage
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/blang/semver"
 	"github.com/carolynvs/magex/pkg"
 	"github.com/carolynvs/magex/shx"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -44,15 +44,14 @@ func EnsureZeitgeist(version string) error {
 	}
 
 	if _, err := semver.ParseTolerant(version); err != nil {
-		return errors.Wrapf(
-			err,
-			"%s was not SemVer-compliant. Cannot continue.",
-			version,
+		return fmt.Errorf(
+			"%s was not SemVer-compliant, cannot continue: %w",
+			version, err,
 		)
 	}
 
 	if err := pkg.EnsurePackage(zeitgeistModule, version); err != nil {
-		return errors.Wrap(err, "ensuring package")
+		return fmt.Errorf("ensuring package: %w", err)
 	}
 
 	return nil
@@ -61,7 +60,7 @@ func EnsureZeitgeist(version string) error {
 // VerifyDeps runs zeitgeist to verify dependency versions
 func VerifyDeps(version, basePath, configPath string, localOnly bool) error {
 	if err := EnsureZeitgeist(version); err != nil {
-		return errors.Wrap(err, "ensuring zeitgeist is installed")
+		return fmt.Errorf("ensuring zeitgeist is installed: %w", err)
 	}
 
 	args := []string{"validate"}
@@ -78,7 +77,7 @@ func VerifyDeps(version, basePath, configPath string, localOnly bool) error {
 	}
 
 	if err := shx.RunV(zeitgeistCmd, args...); err != nil {
-		return errors.Wrap(err, "running zeitgeist")
+		return fmt.Errorf("running zeitgeist: %w", err)
 	}
 
 	return nil

--- a/mage/git.go
+++ b/mage/git.go
@@ -17,7 +17,7 @@ limitations under the License.
 package mage
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"sigs.k8s.io/release-utils/command"
 )
@@ -76,7 +76,7 @@ func EnsureGitConfig() error {
 		gitConfigNameKey,
 		gitConfigNameValue,
 	).RunSuccess(); err != nil {
-		return errors.Wrapf(err, "configuring git %s", gitConfigNameKey)
+		return fmt.Errorf("configuring git %s: %w", gitConfigNameKey, err)
 	}
 
 	if err := command.New(
@@ -86,7 +86,7 @@ func EnsureGitConfig() error {
 		gitConfigEmailKey,
 		gitConfigEmailValue,
 	).RunSuccess(); err != nil {
-		return errors.Wrapf(err, "configuring git %s", gitConfigEmailKey)
+		return fmt.Errorf("configuring git %s: %w", gitConfigEmailKey, err)
 	}
 
 	return nil

--- a/util/common_test.go
+++ b/util/common_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,7 +25,6 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 

--- a/version/command.go
+++ b/version/command.go
@@ -17,7 +17,8 @@ limitations under the License.
 package version
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +38,7 @@ func Version() *cobra.Command {
 			if outputJSON {
 				out, err := v.JSONString()
 				if err != nil {
-					return errors.Wrap(err, "unable to generate JSON from version info")
+					return fmt.Errorf("unable to generate JSON from version info: %w", err)
 				}
 				cmd.Println(out)
 			} else {


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
This removes the direct `github.com/pkg/errors` dependency while using the native golang error wrapping.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed direct `github.com/pkg/errors` dependency by using golang native error wrapping.
```
