### PR TITLE
add an option to choose an ASCII font

### DIFF
--- a/version/command.go
+++ b/version/command.go
@@ -26,7 +26,7 @@ import (
 // ```go
 //	rootCmd.AddCommand(version.Version())
 // ```
-func Version() *cobra.Command {
+func Version(fontName string) *cobra.Command {
 	var outputJSON bool
 	cmd := &cobra.Command{
 		Use:   "version",
@@ -35,6 +35,12 @@ func Version() *cobra.Command {
 			v := GetVersionInfo()
 			v.Name = cmd.Root().Name()
 			v.Description = cmd.Root().Short
+
+			v.FontName = ""
+			if validFont := v.CheckFontName(fontName); validFont {
+				v.FontName = fontName
+			}
+
 			if outputJSON {
 				out, err := v.JSONString()
 				if err != nil {

--- a/version/command_test.go
+++ b/version/command_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	v := version.Version()
+	v := version.Version("fender")
 	err := v.Execute()
 	if err != nil {
 		t.Errorf("%v", err)
@@ -31,7 +31,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestVersionJson(t *testing.T) {
-	v := version.Version()
+	v := version.Version("")
 	v.SetArgs([]string{"--json"})
 	err := v.Execute()
 	if err != nil {

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,7 @@ package version
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"runtime"
 	"runtime/debug"
 	"strings"
@@ -55,6 +56,7 @@ type Info struct {
 	Platform     string `json:"platform"`
 
 	ASCIIName   string `json:"-"`
+	FontName    string `json:"-"`
 	Name        string `json:"-"`
 	Description string `json:"-"`
 }
@@ -99,7 +101,7 @@ func (i *Info) String() string {
 	// name and description are optional.
 	if i.Name != "" {
 		if i.ASCIIName == "true" {
-			f := figure.NewFigure(strings.ToUpper(i.Name), "", true)
+			f := figure.NewFigure(strings.ToUpper(i.Name), i.FontName, true)
 			_, _ = fmt.Fprint(w, f.String())
 		}
 		_, _ = fmt.Fprint(w, i.Name)
@@ -129,4 +131,17 @@ func (i *Info) JSONString() (string, error) {
 	}
 
 	return string(b), nil
+}
+
+func (i *Info) CheckFontName(fontName string) bool {
+	assetNames := figure.AssetNames()
+
+	for _, font := range assetNames {
+		if strings.Contains(font, fontName) {
+			return true
+		}
+	}
+
+	fmt.Fprintln(os.Stderr, "font not valid, using default")
+	return false
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

- add an option to choose an ASCII font
the lib we use to print ASCII fonts has several fonts available to use right away.
So we can enable that when configuring the version in the application

For example: 
```
[fonts/italic.flf fonts/smisome1.flf fonts/tinker-toy.flf fonts/basic.flf fonts/cricket.flf fonts/elite.flf fonts/puffy.flf fonts/shadow.flf fonts/smslant.flf fonts/maxfour.flf fonts/roman.flf fonts/rozzo.flf fonts/smtengwar.flf fonts/big.flf fonts/chunky.flf fonts/linux.flf fonts/stampatello.flf fonts/avatar.flf fonts/nipples.flf fonts/relief2.flf fonts/doh.flf fonts/doom.flf fonts/eftirobot.flf fonts/smshadow.flf fonts/usa
flag.flf fonts/3-d.flf fonts/alligator.flf fonts/caligraphy.flf fonts/drpepper.flf fonts/goofy.flf fonts/kban.flf fonts/mike.flf fonts/mirror.flf fonts/barbwire.flf fonts/catwalk.flf fonts/cybermedium.flf fonts/rounded.flf fonts/script.flf fonts/ticksslant.flf fonts/nancyj-underlined.flf fonts/slscript.flf fonts/standard.flf fonts/tengwar.flf fonts/eftiwall.flf fonts/fourtops.flf fonts/letters.flf fonts/diamond.flf fonts/gra
ffiti.flf fonts/relief.flf fonts/eftifont.flf fonts/pebbles.flf fonts/rowancap.flf fonts/lean.flf fonts/nancyj.flf fonts/lockergnome.flf fonts/runyc.flf fonts/slide.flf fonts/tanja.flf fonts/bubble.flf fonts/contessa.flf fonts/isometric4.flf fonts/smscript.flf fonts/thin.flf fonts/alphabet.flf fonts/binary.flf fonts/rectangles.flf fonts/threepoint.flf fonts/alligator2.flf fonts/ivrit.flf fonts/morse.flf fonts/jerusalem.flf f
onts/ntgreek.flf fonts/peaks.flf fonts/block.flf fonts/cosmike.flf fonts/epic.flf fonts/eftipiti.flf fonts/fuzzy.flf fonts/speed.flf fonts/banner3-D.flf fonts/cosmic.flf fonts/digital.flf fonts/ticks.flf fonts/eftitalic.flf fonts/smkeyboard.flf fonts/straight.flf fonts/weird.flf fonts/banner3.flf fonts/short.flf fonts/small.flf fonts/bell.flf fonts/dotmatrix.flf fonts/twopoint.flf fonts/wavy.flf fonts/contrast.flf fonts/o8.f
lf fonts/trek.flf fonts/pawp.flf fonts/tsalagi.flf fonts/bigchief.flf fonts/hollywood.flf fonts/isometric3.flf fonts/5lineoblique.flf fonts/pyramid.flf fonts/bulbhead.flf fonts/eftichess.flf fonts/runic.flf fonts/starwars.flf fonts/3x5.flf fonts/coinstak.flf fonts/ogre.flf fonts/moscow.flf fonts/cybersmall.flf fonts/larry3d.flf fonts/lcd.flf fonts/marquee.flf fonts/nancyj-fancy.flf fonts/stellar.flf fonts/computer.flf fonts/
cursive.flf fonts/jazmine.flf fonts/colossal.flf fonts/rot13.flf fonts/thick.flf fonts/serifcap.flf fonts/term.flf fonts/tombstone.flf fonts/eftiwater.flf fonts/gothic.flf fonts/isometric1.flf fonts/mnemonic.flf fonts/poison.flf fonts/banner.flf fonts/cyberlarge.flf fonts/katakana.flf fonts/rev.flf fonts/slant.flf fonts/stop.flf fonts/calgphy2.flf fonts/invita.flf fonts/madrid.flf fonts/isometric2.flf fonts/mini.flf fonts/pe
pper.flf fonts/sblood.flf fonts/univers.flf fonts/acrobatic.flf fonts/banner4.flf fonts/fender.flf]
```

in real usage:

```go
...
func init() {
	rootCmd.AddCommand(version.Version("starwars"))
}
...
```

```
$ ./ascii version
  ______   ______        _______. __    _______ .__   __.
 /      | /  __  \      /       ||  |  /  _____||  \ |  |
|  ,----'|  |  |  |    |   (----`|  | |  |  __  |   \|  |
|  |     |  |  |  |     \   \    |  | |  | |_ | |  . `  |
|  `----.|  `--'  | .----)   |   |  | |  |__| | |  |\   |
 \______| \______/  |_______/    |__|  \______| |__| \__|
cosign

GitVersion:    (devel)
GitCommit:     unknown
GitTreeState:  unknown
BuildDate:     unknown
GoVersion:     go1.18
Compiler:      gc
Platform:      darwin/arm64
```

using an invalid font name

```
$ ./ascii version
font not valid, using default
   ____    ___    ____    ___    ____   _   _
  / ___|  / _ \  / ___|  |_ _|  / ___| | \ | |
 | |     | | | | \___ \   | |  | |  _  |  \| |
 | |___  | |_| |  ___) |  | |  | |_| | | |\  |
  \____|  \___/  |____/  |___|  \____| |_| \_|
cosign

GitVersion:    (devel)
GitCommit:     unknown
GitTreeState:  unknown
BuildDate:     unknown
GoVersion:     go1.18
Compiler:      gc
Platform:      darwin/arm64
```

/assign @saschagrunert @n3wscott @puerco 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add an option to choose an ASCII font
```
