### PR TITLE
add WithFont function

### DIFF
--- a/version/command.go
+++ b/version/command.go
@@ -26,7 +26,19 @@ import (
 // ```go
 //	rootCmd.AddCommand(version.Version())
 // ```
-func Version(fontName string) *cobra.Command {
+func Version() *cobra.Command {
+	return version("")
+}
+
+// WithFont returns a cobra command to be added to another cobra command with a select font for ASCII, like:
+// ```go
+//	rootCmd.AddCommand(version.WithFont("starwars"))
+// ```
+func WithFont(fontName string) *cobra.Command {
+	return version(fontName)
+}
+
+func version(fontName string) *cobra.Command {
 	var outputJSON bool
 	cmd := &cobra.Command{
 		Use:   "version",
@@ -37,7 +49,7 @@ func Version(fontName string) *cobra.Command {
 			v.Description = cmd.Root().Short
 
 			v.FontName = ""
-			if validFont := v.CheckFontName(fontName); validFont {
+			if fontName != "" && v.CheckFontName(fontName) {
 				v.FontName = fontName
 			}
 

--- a/version/command_test.go
+++ b/version/command_test.go
@@ -23,7 +23,15 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	v := version.Version("fender")
+	v := version.Version()
+	err := v.Execute()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+}
+
+func TestVersionWithFont(t *testing.T) {
+	v := version.WithFont("fender")
 	err := v.Execute()
 	if err != nil {
 		t.Errorf("%v", err)
@@ -31,7 +39,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestVersionJson(t *testing.T) {
-	v := version.Version("")
+	v := version.Version()
 	v.SetArgs([]string{"--json"})
 	err := v.Execute()
 	if err != nil {


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
/kind feature


#### What this PR does / why we need it:

follow up of https://github.com/kubernetes-sigs/release-utils/pull/44#discussion_r836157061

add a new function called `WithFont` that return the version function with a selected ASCII font

/assign @saschagrunert @puerco 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add WithFont function
```
