### PR TITLE
Bump golangci-lint to v1.45.2

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,7 +1,7 @@
 dependencies:
   # golangci/golangci-lint
   - name: "golangci-lint"
-    version: 1.44.0
+    version: 1.45.2
     refPaths:
     - path: mage/golang.go
       match: defaultGolangCILintVersion\s+=\s+"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"

--- a/mage/golang.go
+++ b/mage/golang.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	// golangci-lint
-	defaultGolangCILintVersion = "v1.44.0"
+	defaultGolangCILintVersion = "v1.45.2"
 	golangciCmd                = "golangci-lint"
 	golangciConfig             = ".golangci.yml"
 	golangciURLBase            = "https://raw.githubusercontent.com/golangci/golangci-lint"


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This commit updates the linter version to v1.45.2. This fixes an error coming in some of our repos.

```
load embedded ruleguard rules: rules/rules.go:13: can't load fmt
```

My guess is that v1.44 has problems with the go version in the image it is run. Bumping the image seems to resolve the error.

For en example of the failure, check [this presubmit run](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_bom/99/pull-bom-verify/1522363292788461568/build-log.txt).

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:

None 

#### Special notes for your reviewer:

Bug failure found in the presubmit runs in https://github.com/kubernetes-sigs/bom/pull/99

/assign @cpanato @saschagrunert
/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
The default `golangci-lint` version in the mage package is now  v1.45.2.
```
