### PR TITLE
return the git version from the one that is passed from the ldflags due to an issue in upstream

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -84,6 +84,12 @@ func getGitVersion(bi *debug.BuildInfo) string {
 	if bi == nil {
 		return unknown
 	}
+
+	// TODO: remove this when the issue https://github.com/golang/go/issues/29228 is fixed
+	if bi.Main.Version == "(devel)" || bi.Main.Version == "" {
+		return gitVersion
+	}
+
 	return bi.Main.Version
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

- return the git version from the one that is passed from the ldflags due to an issue in upstream

the ` debug.ReadBuildInfo()` works for most of the parameters we use, but for the git version it is always returning `(devel)`, so we need to continue passing the `ldflags` for the gitversion until the issue https://github.com/golang/go/issues/29228 is addressed.


/assign @saschagrunert @xmudrii @palnabarun @Verolop 
cc @kubernetes-sigs/release-engineering 


we will need a patch release for this as well

#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
return the git version from the one that is passed from the ldflags due to an issue in upstream
```
