### PR TITLE
Allow the override of all `version` package variables

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -47,6 +47,12 @@ var (
 	buildDate = unknown
 	// flag to print the ascii name banner
 	asciiName = "true"
+	// goVersion is the used golang version.
+	goVersion = unknown
+	// compiler is the used golang compiler.
+	compiler = unknown
+	// platform is the used os/arch identifier.
+	platform = unknown
 )
 
 type Info struct {
@@ -62,14 +68,6 @@ type Info struct {
 	FontName    string `json:"-"`
 	Name        string `json:"-"`
 	Description string `json:"-"`
-}
-
-func init() {
-	buildInfo := getBuildInfo()
-	gitVersion = getGitVersion(buildInfo)
-	gitCommit = getCommit(buildInfo)
-	gitTreeState = getDirty(buildInfo)
-	buildDate = getBuildDate(buildInfo)
 }
 
 func getBuildInfo() *debug.BuildInfo {
@@ -131,15 +129,41 @@ func getKey(bi *debug.BuildInfo, key string) string {
 
 // GetVersionInfo represents known information on how this binary was built.
 func GetVersionInfo() Info {
+	buildInfo := getBuildInfo()
+	gitVersion = getGitVersion(buildInfo)
+	if gitCommit == unknown {
+		gitCommit = getCommit(buildInfo)
+	}
+
+	if gitTreeState == unknown {
+		gitTreeState = getDirty(buildInfo)
+	}
+
+	if buildDate == unknown {
+		buildDate = getBuildDate(buildInfo)
+	}
+
+	if goVersion == unknown {
+		goVersion = runtime.Version()
+	}
+
+	if compiler == unknown {
+		compiler = runtime.Compiler
+	}
+
+	if platform == unknown {
+		platform = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+
 	return Info{
 		ASCIIName:    asciiName,
 		GitVersion:   gitVersion,
 		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,
 		BuildDate:    buildDate,
-		GoVersion:    runtime.Version(),
-		Compiler:     runtime.Compiler,
-		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		GoVersion:    goVersion,
+		Compiler:     compiler,
+		Platform:     platform,
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This now makes it possible to override all variables via the `-X` ldflag, for example:

```go
package main

import (
	"fmt"

	"sigs.k8s.io/release-utils/version"
)

func main() {
	v := version.GetVersionInfo()
	fmt.Print(v.String())
}
```

```
> go run -ldflags '\
    -X sigs.k8s.io/release-utils/version.gitVersion=1 \
    -X sigs.k8s.io/release-utils/version.gitCommit=2 \
    -X sigs.k8s.io/release-utils/version.gitTreeState=3 \
    -X sigs.k8s.io/release-utils/version.buildDate=4 \
    -X sigs.k8s.io/release-utils/version.goVersion=5 \
    -X sigs.k8s.io/release-utils/version.compiler=6 \
    -X sigs.k8s.io/release-utils/version.platform=7' \
    main.go
GitVersion:    1
GitCommit:     2
GitTreeState:  3
BuildDate:     4
GoVersion:     5
Compiler:      6
Platform:      7
```
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/kubernetes-sigs/release-utils/issues/59
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Allow overriding of all variables in the `version` package by using the `-ldflags` `-X` flag.
```
