### PR TITLE
http: Reduce verbosity in agent

### DIFF
--- a/http/agent.go
+++ b/http/agent.go
@@ -126,8 +126,7 @@ func (a *Agent) Get(url string) (content []byte, err error) {
 
 // GetRequest sends a GET request to a URL and returns the request and response
 func (a *Agent) GetRequest(url string) (response *http.Response, err error) {
-	logrus.Infof("Sending GET request to %s", url)
-	logrus.Debug()
+	logrus.Debugf("Sending GET request to %s", url)
 	try := 0
 	for {
 		response, err = a.AgentImplementation.SendGetRequest(a.Client(), url)
@@ -162,9 +161,7 @@ func (a *Agent) Post(url string, postData []byte) (content []byte, err error) {
 
 // PostRequest sends the postData in a POST request to a URL and returns the request object
 func (a *Agent) PostRequest(url string, postData []byte) (response *http.Response, err error) {
-	logrus.Infof("Sending POST request to %s", url)
-	logrus.Debug(a.options.String())
-
+	logrus.Debugf("Sending POST request to %s", url)
 	try := 0
 	for {
 		response, err = a.AgentImplementation.SendPostRequest(a.Client(), url, postData, a.options.PostContentType)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This commit reduces the http verbosity in the https agent. It will not print the requests
made unless logrus is at debug level.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
The HTTP agent is now less verbose, it will not log each request anymore unless the logger is in debug mode 
```
