### PR TITLE
update git describe with --always flag instead of --match=v*

### DIFF
--- a/mage/version.go
+++ b/mage/version.go
@@ -24,7 +24,7 @@ import (
 
 // getVersion gets a description of the commit, e.g. v0.30.1 (latest) or v0.30.1-32-gfe72ff73 (canary)
 func getVersion() (string, error) {
-	version, err := shx.Output("git", "describe", "--tags", "--match=v*")
+	version, err := shx.Output("git", "describe", "--tags", "--always")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind bug

#### What this PR does / why we need it:

- update git describe with --always flag instead of --match=v*

if the repo does not have any tags the command `git describe --tags --match=v*` fails with `fatal: No names found, cannot describe anything.`

using the `git describe --tags --always` it return the hash if there is no tag.


/assign @saschagrunert @puerco @xmudrii @Verolop 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
