### PR TITLE
default tools bump

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -184,7 +184,6 @@ linters-settings:
       - hexLiteral
       - httpNoBody
       - ifElseChain
-      - ioutilDeprecated
       - methodExprCall
       - newDeref
       - octalLiteral

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,21 +1,28 @@
 dependencies:
   # golangci/golangci-lint
   - name: "golangci-lint"
-    version: 1.51.2
+    version: 1.52.2
     refPaths:
-    - path: mage/golang.go
-      match: defaultGolangCILintVersion\s+=\s+"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+      - path: mage/golang.go
+        match: defaultGolangCILintVersion\s+=\s+"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+
+  # ko
+  - name: "ko"
+    version: 0.13.0
+    refPaths:
+      - path: mage/ko.go
+        match: defaultKoVersion\s+=\s+"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
 
   # k8s.io/repo-infra
   - name: "repo-infra"
     version: 0.2.5
     refPaths:
-    - path: mage/boilerplate.go
-      match: defaultRepoInfraVersion\s+=\s+"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
+      - path: mage/boilerplate.go
+        match: defaultRepoInfraVersion\s+=\s+"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
 
   # sigs.k8s.io/zeitgeist
   - name: "zeitgeist"
-    version: 0.3.0
+    version: 0.4.1
     refPaths:
-    - path: mage/dependency.go
-      match: defaultZeitgeistVersion\s+=\s+"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+      - path: mage/dependency.go
+        match: defaultZeitgeistVersion\s+=\s+"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"

--- a/mage/cosign.go
+++ b/mage/cosign.go
@@ -25,7 +25,7 @@ import (
 	"github.com/carolynvs/magex/pkg/downloads"
 )
 
-const defaultCosignVersion = "v1.7.1"
+const defaultCosignVersion = "v2.0.0"
 
 // EnsureCosign makes sure that the specified cosign version is available
 func EnsureCosign(version string) error {

--- a/mage/dependency.go
+++ b/mage/dependency.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// zeitgeist
-	defaultZeitgeistVersion = "v0.3.0"
+	defaultZeitgeistVersion = "v0.4.1"
 	zeitgeistCmd            = "zeitgeist"
 	zeitgeistModule         = "sigs.k8s.io/zeitgeist"
 )

--- a/mage/golang.go
+++ b/mage/golang.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	// golangci-lint
-	defaultGolangCILintVersion = "v1.51.2"
+	defaultGolangCILintVersion = "v1.52.2"
 	golangciCmd                = "golangci-lint"
 	golangciConfig             = ".golangci.yml"
 	golangciURLBase            = "https://raw.githubusercontent.com/golangci/golangci-lint"

--- a/mage/ko.go
+++ b/mage/ko.go
@@ -25,7 +25,7 @@ import (
 	"github.com/carolynvs/magex/pkg/downloads"
 )
 
-const defaultKoVersion = "0.11.2"
+const defaultKoVersion = "0.13.0"
 
 // EnsureKO
 func EnsureKO(version string) error {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

- update ko default install to 0.13.0
- update cosign to v2.0.0
- update zeitgeist to v0.4.1
- update golangci-lint to v1.52.2

/assign @saschagrunert @palnabarun @xmudrii
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- update ko default install to 0.13.0
- update cosign to v2.0.0
- update zeitgeist to v0.4.1
- update golangci-lint to v1.52.2

```
