### PR TITLE
set output to stdout when printing the version

### DIFF
--- a/mage/dependency.go
+++ b/mage/dependency.go
@@ -53,6 +53,7 @@ func EnsureZeitgeist(version string) error {
 	if err := pkg.EnsurePackageWith(pkg.EnsurePackageOptions{
 		Name:           zeitgeistModule,
 		DefaultVersion: version,
+		VersionCommand: "version",
 	}); err != nil {
 		return fmt.Errorf("ensuring package: %w", err)
 	}

--- a/magefile.go
+++ b/magefile.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/carolynvs/magex/pkg"
-
 	"sigs.k8s.io/release-utils/mage"
 )
 
@@ -63,11 +61,6 @@ func Test() error {
 
 // Verify runs repository verification scripts
 func Verify() error {
-	fmt.Println("Ensuring mage is available...")
-	if err := pkg.EnsureMage(""); err != nil {
-		return err
-	}
-
 	fmt.Println("Running copyright header checks...")
 	if err := mage.VerifyBoilerplate("", binDir, boilerplateDir, true); err != nil {
 		return err

--- a/version/command.go
+++ b/version/command.go
@@ -56,6 +56,7 @@ func version(fontName string) *cobra.Command {
 			if fontName != "" && v.CheckFontName(fontName) {
 				v.FontName = fontName
 			}
+			cmd.SetOut(cmd.OutOrStdout())
 
 			if outputJSON {
 				out, err := v.JSONString()


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

- set output to stdout when printing the version

The cobra checks if there is an out otherwise that prints to stderr, forcing to use stdout when printing the version

- add version command to check
- drop check mage check


/assign @saschagrunert @xmudrii @ameukam 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
set output to stdout when printing the version
```
