### PR TITLE
tar/extract: ignore error if directory exists

### DIFF
--- a/tar/tar.go
+++ b/tar/tar.go
@@ -143,7 +143,7 @@ func Extract(tarFilePath, destinationPath string) error {
 			case tar.TypeDir:
 				targetDir := filepath.Join(destinationPath, header.Name)
 				logrus.Tracef("Creating directory %s", targetDir)
-				if err := os.Mkdir(targetDir, os.FileMode(0o755)); err != nil {
+				if err := os.MkdirAll(targetDir, os.FileMode(0o755)); err != nil {
 					return false, fmt.Errorf("create target directory: %w", err)
 				}
 			case tar.TypeSymlink:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`tar.Extract` doesn't work well in case the .tar.gz archive doesn't have any directory in it. In that case, extracting would fail with the error that directory already exists.

This PR proposes fixing that problem by using `MkdirAll` instead of `Mkdir`. `MkdirAll` doesn't throw an error if the directory already exists:

> If path is already a directory, MkdirAll does nothing and returns nil.

Reproducible example: take [cni-plugins archive](https://github.com/containernetworking/plugins/releases/tag/v1.3.0) and try to extract it. Extracting would fail with the described error.

#### Does this PR introduce a user-facing change?
```release-note
tar.Extract: ignore error if directory exists
```

/assign @saschagrunert @cpanato @puerco 
cc @kubernetes-sigs/release-engineering 