### PR TITLE
Updates go, golangci-lint, cosign

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -13,6 +13,13 @@ dependencies:
       - path: mage/ko.go
         match: defaultKoVersion\s+=\s+"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
 
+  # cosign
+  - name: "cosign"
+    version: 2.2.0
+    refPaths:
+      - path: mage/cosign.go
+        match: defaultCosignVersion\s+=\s+"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+
   # k8s.io/repo-infra
   - name: "repo-infra"
     version: 0.2.5

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,7 +1,7 @@
 dependencies:
   # golangci/golangci-lint
   - name: "golangci-lint"
-    version: 1.53.3
+    version: 1.54.2
     refPaths:
       - path: mage/golang.go
         match: defaultGolangCILintVersion\s+=\s+"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/release-utils
 
-go 1.19
+go 1.20
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/mage/cosign.go
+++ b/mage/cosign.go
@@ -25,7 +25,7 @@ import (
 	"github.com/uwu-tools/magex/pkg/downloads"
 )
 
-const defaultCosignVersion = "v2.1.1"
+const defaultCosignVersion = "v2.2.0"
 
 // EnsureCosign makes sure that the specified cosign version is available
 func EnsureCosign(version string) error {

--- a/mage/golang.go
+++ b/mage/golang.go
@@ -37,11 +37,11 @@ import (
 
 const (
 	// golangci-lint
-	defaultGolangCILintVersion = "v1.53.3"
+	defaultGolangCILintVersion = "v1.54.2"
 	golangciCmd                = "golangci-lint"
 	golangciConfig             = ".golangci.yml"
 	golangciURLBase            = "https://raw.githubusercontent.com/golangci/golangci-lint"
-	defaultMinGoVersion        = "1.19"
+	defaultMinGoVersion        = "1.20"
 )
 
 // Ensure golangci-lint is installed and on the PATH.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature


#### What this PR does / why we need it:

- set minimum go version to 1.20
- bump cosign to v2.2.0
- bump golangci-lint to v1.54.2

/hold for test-infra job change to test with go1.21

/assign @saschagrunert @xmudrii @Verolop 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- set minimum go version to 1.20
- bump cosign to v2.2.0
- bump golangci-lint to v1.54.2
```
