### PR TITLE
Log error message on editor error

### DIFF
--- a/editor/editor.go
+++ b/editor/editor.go
@@ -129,7 +129,7 @@ func (e Editor) Launch(path string) error {
 				return fmt.Errorf("unable to launch the editor %q", strings.Join(e.Args, " "))
 			}
 		}
-		return fmt.Errorf("there was a problem with the editor %q", strings.Join(e.Args, " "))
+		return fmt.Errorf("there was a problem with the editor %q: %w", strings.Join(e.Args, " "), err)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

#### What this PR does / why we need it:

When running the `krel` release notes tool, there have been infrequent but repeated instances of exiting editors producing errors. See [this thread](https://kubernetes.slack.com/archives/CN1KH4K9A/p1643580372033969) from January 2022, and then a [follow up report](https://kubernetes.slack.com/archives/CN1KH4K9A/p1701202755665649?thread_ts=1643580372.033969&cid=CN1KH4K9A) here in November 2023. This is a persistent, but highly intermittent issue. Users have also reported that it only seems to occur with `vi`.

The krel output logging in this instance says simply:

```
- Fix note for PR #97252? (y/N) (1/10) 
y
INFO Opening file with editor [vi /var/folders/94/yvfr6pns4vxd1bz_cr2nwpkc0000gn/T/release-notes-map-1064630614.yaml] 
FATA creating Draft PR: while running release notes fix flow: while editing release note: while launching editor: there was a problem with the editor "vi" 
```

This change modifies the error log to include the `err` that led to this case, so that future instances can lead to more productive debugging.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Improve error logging during external editor failure
```
