### PR TITLE
http agent: Properly wrap buffer reading error

### DIFF
--- a/http/agent.go
+++ b/http/agent.go
@@ -18,7 +18,6 @@ package http
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -214,7 +213,7 @@ func (impl *defaultAgentImplementation) SendGetRequest(client *http.Client, url 
 func (a *Agent) readResponseToByteArray(response *http.Response) ([]byte, error) {
 	var b bytes.Buffer
 	if err := a.readResponse(response, &b); err != nil {
-		return nil, errors.New("reading")
+		return nil, fmt.Errorf("reading array buffer: %w", err)
 	}
 	return b.Bytes(), nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

This PR properly wraps errors when reading HTTP responses in the agent so that the error code can
by communicated downstream.

This should fix the [ci-fast-forward](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-fast-forward/1775434576424865792) job by wiring the 404 response code to the release gcb package:

https://github.com/kubernetes/release/blob/367414ceffffa3f97896b8c5a78df55f072ff303/pkg/gcp/gcb/gcb.go#L400-L402

Thanks @dims and @cpanato for investigating it

#### Which issue(s) this PR fixes:

Fixes the `ci-fast-forward` job

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
FIxed a bug where errors were not properly wrapped in the HTTP agent array buffering code
```
