### PR TITLE
http.Agent: Add `Group` variants for parallel fetching

### DIFF
--- a/http/doc.go
+++ b/http/doc.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package http provides a configurable agent to talk to http servers.
+
+# Function Families
+
+It provides three families of functions for the GET, POST and HEAD methods
+that return the raw http.Response, the response contents as a byte slice or to
+write the response to a writer.
+
+Each of these functions also provide a _Group_ equivalent that takes a list
+of URLs and performs the requests in parallel. The easiest way to understand
+the functions is this expression:
+
+	METHOD[Request|ToWriter][Group]
+
+So, for examaple, the functions for the POST method include the following
+variations, note that the Group variants take and return the same arguments
+but in plural form, ie same type but a slice:
+
+	Post(string url, []byte postData) ([]byte, error)
+	PostRequest(string url, []byte postData) (*http.Response, error)
+	PostToWriter(io.Writer w, string url, []byte postData) error
+	PostGroup([]string urls, [][]byte postData) ([][]byte, []error)
+	PostRequestGroup([]string urls, [][]byte postData) ([]*http.Response, []error)
+	PostToWriterGroup([]io.Writer w, []string urls, [][]byte postData) []error
+
+# Group Requests
+
+All the _Group_ families perform the requests in parallel. The number of
+simultaneous requests can be controlled with the .WithMaxParallel(int) option:
+
+	# Create an HTTP agent that performs two requests at a time:
+	agent := http.NewAgent().WithMaxParallel(2)
+
+All group requests take arguments in slices and return data and errors in slices
+guaranteed to be of the same length and order as the arguments.
+
+To check the returned error slice for success in a single shot the errors.Join()
+function comes in handy:
+
+	responses, errs := agent.GetGroup(urlList)
+	if errors.Join(errs) != nil {
+	   // Handle errors here
+	}
+
+# Single and Multiple Writer Output
+
+The ToWriterGroup variants take a list of writers in their first arguments.
+Usually, the data returned by the requests will be written to each corresponding
+writer in the slice (eg request #5 to writer #5). There is an exception though,
+if the writer slice contains a single writer, the data from all requests will
+be written - in order - into the single writer. This allows for simple piping to
+a single output sink (ie all output to STDOUT).
+
+# Example
+
+The following example shows a code snippet that fetches ten photographs in parallel
+and writes them to disk.
+*/
+package http

--- a/http/example_multi_test.go
+++ b/http/example_multi_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/release-utils/http"
+)
+
+func Example() {
+	// This example fetches 10 photographs from flick in parallel
+	agent := http.NewAgent()
+	w := []io.Writer{}
+	urls := []string{
+		"https://live.staticflickr.com/65535/53863838503_3490725fab.jpg",
+		"https://live.staticflickr.com/65535/53862224352_a9949bb818.jpg",
+		"https://live.staticflickr.com/65535/53863076331_570818d62f_w.jpg",
+		"https://live.staticflickr.com/65535/53863751331_aa8cc7c233_w.jpg",
+		"https://live.staticflickr.com/65535/53862636262_3ec860a652.jpg",
+		"https://live.staticflickr.com/65535/53863034561_079ea0a87b_z.jpg",
+		"https://live.staticflickr.com/65535/53862940596_5a991b2271_w.jpg",
+		"https://live.staticflickr.com/65535/53863423169_90f8e13b7f_z",
+		"https://live.staticflickr.com/65535/53863136849_965bd39df1_n.jpg",
+		"https://live.staticflickr.com/65535/53863672556_1050bbf01b_n.jpg",
+	}
+
+	for i := range urls {
+		f, err := os.Create(fmt.Sprintf("/tmp/photo-%d.jpg", i))
+		if err != nil {
+			logrus.Fatal("error opening file")
+		}
+		w = append(w, f)
+	}
+
+	defer func() {
+		for i := range w {
+			w[i].(*os.File).Close()
+		}
+	}()
+
+	errs := agent.GetToWriterGroup(w, urls)
+	if errors.Join(errs...) != nil {
+		logrus.Fatalf("%d errors fetching photos: %v", len(errs), errors.Join(errs...))
+	}
+	// output:
+}

--- a/http/http.go
+++ b/http/http.go
@@ -20,7 +20,11 @@ import (
 	"bytes"
 )
 
-// GetURLResponse returns the HTTP response for the provided URL if the request succeeds.
+// GetURLResponse performs a get request and returns the response contents as a
+// string if successful.
+//
+// Deprecated: Use http.Agent.Get() instead. This function will be removed in a
+// future version of this package.
 func GetURLResponse(url string, trim bool) (string, error) {
 	resp, err := NewAgent().Get(url)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind documentation

#### What this PR does / why we need it:

This pull request adds `*Group` variants of the existing `http.Agent` methods to support parallel fetching of multiple URLs. The new included docs explain it better:

```
Each of these functions also provide a _Group_ equivalent that takes a list of URLs and performs the requests in parallel. The easiest way to understand the functions is this expression:

METHOD[Request|ToWriter][Group]

So, for examaple, the functions for the POST method include the following variations, note that the Group
variants take and return the same arguments but in plural form, ie same type but a slice:

 Post(string url, []byte postData) ([]byte, error)
 PostRequest(string url, []byte postData) (*http.Response, error)
 PostToWriter(io.Writer w, string url, []byte postData) error
 PostGroup([]string urls, [][]byte postData) ([][]byte, []error)
 PostRequestGroup([]string urls, [][]byte postData) ([]*http.Response, []error)
 PostToWriterGroup([]io.Writer w, []string urls, [][]byte postData) []error
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Most of the line changes in the PR is documentation, the real code is in 482d365c10a95f98082b4b9cf8ed8122b90dc9c1

I added a doc.go to document the module better and an example to illustrate the new functions.

The functions rely on the existing fetch logic, I added a test to check that the parallel logic returns values in the expected order.

Finally I marked as deprecated the http.GetURLResponse() function to encourage developers to use the agent directly.

#### Does this PR introduce a user-facing change?

```release-note
The `http.Agent` now has `*Group` variants of its functions to support parallel fetching o lists of URLs.
```
