### PR TITLE
Add util.IsDir method and tests

### DIFF
--- a/util/common.go
+++ b/util/common.go
@@ -488,6 +488,19 @@ func Exists(path string) bool {
 	return true
 }
 
+// IsDir returns true if the path is a directory.
+func IsDir(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	if info.IsDir() {
+		return true
+	}
+	return false
+}
+
 // WrapText wraps a text.
 func WrapText(originalText string, lineSize int) (wrappedText string) {
 	words := strings.Fields(strings.TrimSpace(originalText))

--- a/util/common_test.go
+++ b/util/common_test.go
@@ -567,3 +567,50 @@ func TestCleanLogFile(t *testing.T) {
 	require.NotEqual(t, originalLog, string(resultingData))
 	require.Equal(t, cleanLog, string(resultingData))
 }
+
+func TestIsDir(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		prepare  func(t *testing.T) string
+		expected bool
+	}{
+		{
+			name: "isdir",
+			prepare: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				return dir
+			},
+			expected: true,
+		},
+		{
+			name: "isfile",
+			prepare: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				path := filepath.Join(dir, "file.txt")
+				require.NoError(t, os.WriteFile(path, []byte("Yo!"), os.FileMode(0o644)))
+				return path
+			},
+			expected: false,
+		},
+		{
+			name: "nonexisting",
+			prepare: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				path := filepath.Join(dir, "not-there.txt")
+				return path
+			},
+			expected: false,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := tc.prepare(t)
+			require.Equal(t, tc.expected, IsDir(path))
+		})
+	}
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This adds a new method `util.IsDir()` that complements `util.Exists()` but for directories


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
The util package has a new convenience function `util.IsDir()` to detect if a path is a directory.
```
