### PR TITLE
Add release workflow with SBOM generation

### DIFF
--- a/.bom.yaml
+++ b/.bom.yaml
@@ -1,0 +1,5 @@
+---
+license: Apache-2.0
+name: sigs.k8s.io/release-utils
+creator:
+  person: The Kubernetes Authors

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # needed to write releases 
+
+    steps:
+      - name: Set tag name
+        shell: bash
+        run: |
+          echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Check out code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 1
+      - name: Set up go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v3
+        with:
+          go-version-file: go.mod
+          check-latest: true  
+          cache: false
+      - name: Install bom
+        uses: kubernetes-sigs/release-actions/setup-bom@2f8b9ec22aedc9ce15039b6c7716aa6c2907df1c # v0.2.0
+      - name: Generate SBOM
+        shell: bash
+        run: |
+          bom generate -c .bom.yaml --format=json -o /tmp/sigs.k8s.io-release-utils-$TAG.spdx.json .
+      - name: Publish Release
+        uses: kubernetes-sigs/release-actions/publish-release@2f8b9ec22aedc9ce15039b6c7716aa6c2907df1c # v0.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          assets: "/tmp/sigs.k8s.io-release-utils-$TAG.spdx.json"
+          sbom: false


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a release workflow to automatically cut the repo releases when pushing a tag. It also generates an SBOM and pushes it to the assets. Here's a sample:

https://github.com/puerco/release-utils/releases/tag/v0.8.4-rc.2

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
k-sigs/release-utils now has an automated release workflow and publishes an SBOM
```
