### PR TITLE
Fix disable retries in http agent

### DIFF
--- a/http/agent.go
+++ b/http/agent.go
@@ -189,6 +189,10 @@ func (a *Agent) PostRequest(u string, postData []byte) (response *http.Response,
 }
 
 func (a *Agent) retryRequest(do func() (*http.Response, error)) (response *http.Response, err error) {
+	if a.options.Retries == 0 {
+		return do()
+	}
+
 	err = retry.Do(func() error {
 		//nolint:bodyclose // The API consumer should close the body
 		response, err = do()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This commit fixes a breaking change in the http agent where disabling retries by setting the retries option to 0 causes the agent to retry forever.

#### Which issue(s) this PR fixes:

Fixes #148

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug in the http agent coming from a change upstream where setting Retries = 0 would cause the agent to retry forever instead of disabling retries.
```
