### PR TITLE
Guard HTTP client race on agent group fetches

### DIFF
--- a/http/agent.go
+++ b/http/agent.go
@@ -95,6 +95,7 @@ func NewAgent() *Agent {
 	return &Agent{
 		AgentImplementation: &defaultAgentImplementation{},
 		options:             &opts,
+		client:              &http.Client{Timeout: opts.Timeout},
 	}
 }
 
@@ -103,9 +104,13 @@ func (a *Agent) SetImplementation(impl AgentImplementation) {
 	a.AgentImplementation = impl
 }
 
-// WithTimeout sets the agent timeout.
+// WithTimeout sets the agent timeout. The new value is also written to the
+// agent's http client, so it must not be called while requests are in flight.
 func (a *Agent) WithTimeout(timeout time.Duration) *Agent {
 	a.options.Timeout = timeout
+	if a.client != nil {
+		a.client.Timeout = timeout
+	}
 
 	return a
 }
@@ -146,20 +151,30 @@ func (a *Agent) WithMaxParallel(workers int) *Agent {
 	return a
 }
 
-// WithClient allows callers to set a custom http client in the agent.
+// WithClient allows callers to set a custom http client in the agent. The
+// agent's timeout is set on it, as it is on the default client; adjust it
+// with WithTimeout.
+//
+// Note: this overwrites the timeout on the provided client. If the same
+// client is shared across agents, the last agent to call WithClient (or
+// WithTimeout) sets the timeout for all of them.
 func (a *Agent) WithClient(c *http.Client) *Agent {
+	if c != nil {
+		c.Timeout = a.options.Timeout
+	}
+
 	a.client = c
 
 	return a
 }
 
-// Client return an net/http client preconfigured with the agent options.
+// Client returns the net/http client preconfigured with the agent options.
+// The client is created with the agent and configured by the With* options,
+// so calling this while requests are in flight is safe.
 func (a *Agent) Client() *http.Client {
 	if a.client == nil {
-		a.client = http.DefaultClient
+		a.client = &http.Client{Timeout: a.options.Timeout}
 	}
-
-	a.client.Timeout = a.options.Timeout
 
 	return a.client
 }
@@ -433,10 +448,12 @@ func (a *Agent) GetRequestGroup(urls []string) ([]*http.Response, []error) {
 	errs := make([]error, len(urls))
 	m := sync.Mutex{}
 
+	client := a.Client()
+
 	for i := range urls {
 		go func(url string) {
 			//nolint: bodyclose // We don't close here as we're returning the response
-			resp, err := a.SendGetRequest(a.Client(), url)
+			resp, err := a.SendGetRequest(client, url)
 
 			m.Lock()
 
@@ -477,12 +494,13 @@ func (a *Agent) PostRequestGroup(urls []string, postData [][]byte) ([]*http.Resp
 	//nolint:gosec // integer overflow highly unlikely
 	t := throttler.New(int(a.options.MaxParallel), len(urls))
 	m := sync.Mutex{}
+	client := a.Client()
 
 	for i := range urls {
 		go func(url string, pdata []byte) {
 			//nolint: bodyclose // We don't close here as we're returning the raw response
 			resp, err := a.SendPostRequest(
-				a.Client(), url, pdata, a.options.PostContentType,
+				client, url, pdata, a.options.PostContentType,
 			)
 
 			m.Lock()

--- a/http/agent_test.go
+++ b/http/agent_test.go
@@ -18,10 +18,12 @@ package http_test
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -180,4 +182,60 @@ func TestWithClient(t *testing.T) {
 	response, err := agent.Get(server.URL)
 	require.NoError(t, err)
 	assert.Equal(t, "custom-client-response", string(response))
+}
+
+// TestClientConfiguredByOptions verifies the agent's timeout lands on the
+// client at configure time, whatever the order of the With calls. Client()
+// itself no longer configures anything: the goroutines the group methods
+// spawn call it concurrently, so it has to be a read.
+func TestClientConfiguredByOptions(t *testing.T) {
+	agent := rhttp.NewAgent().WithTimeout(9 * time.Second)
+	assert.Equal(t, 9*time.Second, agent.Client().Timeout)
+
+	// A custom client picks up the timeout already set...
+	custom := &http.Client{}
+	agent.WithClient(custom)
+	assert.Equal(t, 9*time.Second, custom.Timeout)
+
+	// ...and one set afterwards.
+	agent.WithTimeout(11 * time.Second)
+	assert.Equal(t, 11*time.Second, custom.Timeout)
+}
+
+// TestClientLeavesDefaultClientAlone guards against the agent adopting
+// http.DefaultClient as its own, as it used to when no custom client was
+// set: stamping the agent's timeout on it silently reconfigured every other
+// user of the process-wide default.
+func TestClientLeavesDefaultClientAlone(t *testing.T) {
+	before := http.DefaultClient.Timeout
+
+	agent := rhttp.NewAgent().WithTimeout(42 * time.Second)
+	require.NotSame(t, http.DefaultClient, agent.Client())
+	assert.Equal(t, before, http.DefaultClient.Timeout)
+}
+
+// TestGetGroupParallel fetches a group through a real server with real
+// parallelism. Under the race detector it is the regression test for the
+// data race the group methods used to have: every goroutine they spawned
+// called Client(), which wrote the lazily-adopted client and its timeout
+// on every call.
+func TestGetGroupParallel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(r.URL.Path)) //nolint:errcheck,gosec // test server echoing the path back
+	}))
+	defer server.Close()
+
+	urls := make([]string, 20)
+	for i := range urls {
+		urls[i] = fmt.Sprintf("%s/%d", server.URL, i)
+	}
+
+	agent := rhttp.NewAgent().WithMaxParallel(4)
+	bodies, errs := agent.GetGroup(urls)
+	require.Len(t, bodies, len(urls))
+
+	for i := range urls {
+		require.NoError(t, errs[i])
+		assert.Equal(t, fmt.Sprintf("/%d", i), string(bodies[i]))
+	}
 }


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

This commit fixes a race in the http agent code when fetching groups in parallel where the agent would initialize a new http client with possibly different options per fetch.

Now we reuse the agent-wide client for all operations.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
The http agent now maintains a single http client and reuses it for all operations
```
